### PR TITLE
fix: improve FreeBSD socket enumeration

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,35 +5,74 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  lint:
-    name: Lint
+  quality:
+    name: Quality
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Install stable toolchain
-      run: rustup toolchain install stable --profile minimal --component rustfmt --component clippy
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt, clippy
+    - uses: Swatinem/rust-cache@v2
     - name: Check formatting
       run: cargo fmt --all -- --check
+    - name: Check build
+      run: cargo check --all-targets --all-features
     - name: Clippy (all features, deny warnings)
       run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
     name: Test
-    needs: lint
+    needs: quality
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo build --all-targets --all-features
     - name: Test
       run: cargo test --all-targets --all-features
+
+  freebsd:
+    name: Test (FreeBSD)
+    needs: quality
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: cpa.sh {0}
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Start FreeBSD VM
+      uses: cross-platform-actions/action@v1.1.0
+      with:
+        operating_system: freebsd
+        version: "14.3"
+    - name: Install Rust toolchain
+      run: |
+        sudo pkg update
+        sudo pkg install -y curl ca_root_nss
+        fetch https://sh.rustup.rs -o rustup-init.sh
+        sh rustup-init.sh -y --profile minimal --default-toolchain stable
+        . "$HOME/.cargo/env"
+        rustc --version
+        cargo --version
+    - name: Test
+      run: |
+        . "$HOME/.cargo/env"
+        cargo test --all-targets --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,14 @@ authors = ["shellrow <shellrow@foctal.com>"]
 description = "Cross-platform library for network sockets information"
 readme = "README.md"
 repository = "https://github.com/shellrow/netsock"
+documentation = "https://docs.rs/netsock"
 license = "MIT"
 keywords = ["network", "socket"]
 categories = ["network-programming", "os"]
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-unknown-linux-gnu"
 
 [dependencies]
 bitflags = "2.11"

--- a/build.rs
+++ b/build.rs
@@ -2,5 +2,6 @@ fn main() {
     #[cfg(target_os = "freebsd")]
     {
         println!("cargo:rustc-link-lib=procstat");
+        println!("cargo:rustc-link-lib=util");
     }
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -422,4 +422,47 @@ mod tests {
                 .matches(&socket)
         );
     }
+
+    #[test]
+    fn socket_query_matches_remote_endpoint_and_owner_pid() {
+        let socket = tcp_socket();
+
+        assert!(
+            SocketQuery::new()
+                .with_remote_addr(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 10)))
+                .with_remote_port(443)
+                .with_owner_pid(42)
+                .matches(&socket)
+        );
+        assert!(
+            !SocketQuery::new()
+                .with_remote_port(80)
+                .with_owner_pid(100)
+                .matches(&socket)
+        );
+    }
+
+    #[test]
+    fn filter_by_query_skips_non_matches_and_preserves_errors() {
+        let items = vec![
+            Ok(udp_socket()),
+            Err(Error::NotAValidSocket),
+            Ok(tcp_socket()),
+        ];
+        let mut iter = items.into_iter().filter_by_query(
+            SocketQuery::new()
+                .with_protocol_flags(ProtocolFlags::TCP)
+                .with_local_port(8080),
+        );
+
+        assert!(matches!(iter.next(), Some(Err(Error::NotAValidSocket))));
+        assert!(matches!(
+            iter.next(),
+            Some(Ok(SocketInfo {
+                protocol_socket_info: ProtocolSocketInfo::Tcp(_),
+                ..
+            }))
+        ));
+        assert!(iter.next().is_none());
+    }
 }

--- a/src/sys/freebsd/ffi.rs
+++ b/src/sys/freebsd/ffi.rs
@@ -154,10 +154,34 @@ pub struct kinfo_file_socket_compat {
 }
 
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kinfo_file_socket {
+    pub kf_sock_sendq: u32,
+    pub kf_sock_domain0: c_int,
+    pub kf_sock_type0: c_int,
+    pub kf_sock_protocol0: c_int,
+    pub kf_sa_local: sockaddr_storage,
+    pub kf_sa_peer: sockaddr_storage,
+    pub kf_sock_pcb: u64,
+    pub kf_sock_inpcb: u64,
+    pub kf_sock_unpconn: u64,
+    pub kf_sock_snd_sb_state: u16,
+    pub kf_sock_rcv_sb_state: u16,
+    pub kf_sock_recvq: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union kinfo_file_nested_union {
+    pub kf_sock: kinfo_file_socket,
+    pub raw: [u8; 304],
+}
+
+#[repr(C)]
 #[derive(Copy, Clone)]
 pub union kinfo_file_union {
     pub compat: kinfo_file_socket_compat,
-    pub raw: [u8; 304],
+    pub nested: kinfo_file_nested_union,
 }
 
 #[repr(C)]
@@ -184,19 +208,19 @@ const _: [(); 1392] = [(); std::mem::size_of::<kinfo_file>()];
 
 impl kinfo_file {
     pub unsafe fn socket_family(&self) -> c_int {
-        unsafe { self.kf_un.compat.kf_sock_domain }
+        unsafe { self.kf_un.nested.kf_sock.kf_sock_domain0 }
     }
 
     pub unsafe fn socket_protocol(&self) -> c_int {
-        unsafe { self.kf_un.compat.kf_sock_protocol }
+        unsafe { self.kf_un.nested.kf_sock.kf_sock_protocol0 }
     }
 
     pub unsafe fn socket_local_addr(&self) -> &sockaddr_storage {
-        unsafe { &self.kf_un.compat.kf_sa_local }
+        unsafe { &self.kf_un.nested.kf_sock.kf_sa_local }
     }
 
     pub unsafe fn socket_peer_addr(&self) -> &sockaddr_storage {
-        unsafe { &self.kf_un.compat.kf_sa_peer }
+        unsafe { &self.kf_un.nested.kf_sock.kf_sa_peer }
     }
 }
 

--- a/src/sys/freebsd/ffi.rs
+++ b/src/sys/freebsd/ffi.rs
@@ -34,7 +34,7 @@ pub struct kinfo_proc {
     pub ki_sid: i32,
     pub ki_tsid: i32,
     pub ki_jobc: c_int,
-    pub ki_tdev: u64,
+    pub ki_tdev_freebsd11: u32,
     pub ki_siglist: [u32; 4],
     pub ki_sigmask: [u32; 4],
     pub ki_sigignore: [u32; 4],
@@ -71,7 +71,7 @@ pub struct kinfo_proc {
     pub ki_rqindex: c_char,
     pub ki_oncpu_old: c_char,
     pub ki_lastcpu_old: c_char,
-    pub ki_tdname: [c_char; 20],
+    pub ki_tdname: [c_char; 17],
     pub ki_wmesg: [c_char; 9],
     pub ki_login: [c_char; 18],
     pub ki_lockname: [c_char; 9],
@@ -81,6 +81,7 @@ pub struct kinfo_proc {
     pub ki_moretdname: [c_char; 4],
     pub ki_sparestrings: [[c_char; 23]; 2],
     pub ki_spareints: [c_int; 2],
+    pub ki_tdev: u64,
     pub ki_oncpu: c_int,
     pub ki_lastcpu: c_int,
     pub ki_tracer: c_int,
@@ -90,7 +91,7 @@ pub struct kinfo_proc {
     pub ki_jid: c_int,
     pub ki_numthreads: c_int,
     pub ki_tid: i32,
-    pub ki_pri: [u8; 36],
+    pub ki_pri: [u8; 4],
     pub ki_rusage: [u8; 144],
     pub ki_rusage_ch: [u8; 144],
     pub ki_pcb: *mut c_void,
@@ -102,6 +103,9 @@ pub struct kinfo_proc {
     pub ki_sflag: i64,
     pub ki_tdflags: i64,
 }
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+const _: [(); 1088] = [(); std::mem::size_of::<kinfo_proc>()];
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/sys/freebsd/ffi.rs
+++ b/src/sys/freebsd/ffi.rs
@@ -5,6 +5,8 @@
 use std::os::raw::{c_char, c_int, c_uint, c_void};
 
 pub const KERN_PROC_PROC: c_int = 8;
+pub const KF_TYPE_SOCKET: c_int = 2;
+const PATH_MAX: usize = 1024;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -131,7 +133,7 @@ pub struct filestat_list {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_storage {
     pub ss_len: u8,
     pub ss_family: u8,
@@ -141,21 +143,61 @@ pub struct sockaddr_storage {
 }
 
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kinfo_file_socket_compat {
+    pub kf_vnode_type: c_int,
+    pub kf_sock_domain: c_int,
+    pub kf_sock_type: c_int,
+    pub kf_sock_protocol: c_int,
+    pub kf_sa_local: sockaddr_storage,
+    pub kf_sa_peer: sockaddr_storage,
+}
+
+#[repr(C)]
 #[derive(Copy, Clone)]
-pub struct sockstat {
-    pub so_addr: u64,
-    pub so_pcb: u64,
-    pub unp_conn: u64,
-    pub dom_family: c_int,
-    pub proto: c_int,
-    pub so_rcv_sb_state: c_int,
-    pub so_snd_sb_state: c_int,
-    pub sa_local: sockaddr_storage,
-    pub sa_peer: sockaddr_storage,
-    pub sock_type: c_int,
-    pub dname: [c_char; 32],
-    pub sendq: c_uint,
-    pub recvq: c_uint,
+pub union kinfo_file_union {
+    pub compat: kinfo_file_socket_compat,
+    pub raw: [u8; 304],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct kinfo_file {
+    pub kf_structsize: c_int,
+    pub kf_type: c_int,
+    pub kf_fd: c_int,
+    pub kf_ref_count: c_int,
+    pub kf_flags: c_int,
+    pub kf_pad0: c_int,
+    pub kf_offset: i64,
+    pub kf_un: kinfo_file_union,
+    pub kf_status: u16,
+    pub kf_pad1: u16,
+    pub kf_ispare0: c_int,
+    pub kf_cap_rights: [u64; 2],
+    pub kf_cap_spare: u64,
+    pub kf_path: [c_char; PATH_MAX],
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+const _: [(); 1392] = [(); std::mem::size_of::<kinfo_file>()];
+
+impl kinfo_file {
+    pub unsafe fn socket_family(&self) -> c_int {
+        unsafe { self.kf_un.compat.kf_sock_domain }
+    }
+
+    pub unsafe fn socket_protocol(&self) -> c_int {
+        unsafe { self.kf_un.compat.kf_sock_protocol }
+    }
+
+    pub unsafe fn socket_local_addr(&self) -> &sockaddr_storage {
+        unsafe { &self.kf_un.compat.kf_sa_local }
+    }
+
+    pub unsafe fn socket_peer_addr(&self) -> &sockaddr_storage {
+        unsafe { &self.kf_un.compat.kf_sa_peer }
+    }
 }
 
 pub const PS_FST_TYPE_SOCKET: c_int = 3;
@@ -170,16 +212,6 @@ unsafe extern "C" {
         count: *mut c_uint,
     ) -> *mut kinfo_proc;
     pub fn procstat_freeprocs(procstat: *mut procstat, p: *mut kinfo_proc);
-    pub fn procstat_getfiles(
-        procstat: *mut procstat,
-        kp: *mut kinfo_proc,
-        mmapped: c_int,
-    ) -> *mut filestat_list;
-    pub fn procstat_freefiles(procstat: *mut procstat, head: *mut filestat_list);
-    pub fn procstat_get_socket_info(
-        procstat: *mut procstat,
-        fst: *mut filestat,
-        sock: *mut sockstat,
-        errbuf: *mut c_char,
-    ) -> c_int;
+    pub fn kinfo_getfile(pid: c_int, cntp: *mut c_int) -> *mut kinfo_file;
+    pub fn free(ptr: *mut c_void);
 }

--- a/src/sys/freebsd/netstat.rs
+++ b/src/sys/freebsd/netstat.rs
@@ -289,40 +289,12 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr, TcpListener, UdpSocket};
 
     #[test]
+    #[ignore = "requires a stable live FreeBSD process/socket environment"]
     fn test_netstat() {
-        let tcp_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-        let tcp_port = tcp_listener.local_addr().unwrap().port();
-
-        let udp_socket = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-        let udp_port = udp_socket.local_addr().unwrap().port();
-
-        let ns: Vec<_> = iterate_netstat_info(
-            AddressFamilyFlags::IPV4,
-            ProtocolFlags::TCP | ProtocolFlags::UDP,
-        )
-        .unwrap()
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap();
-
-        assert!(ns.iter().any(|socket| {
-            matches!(
-                socket.protocol_socket_info,
-                ProtocolSocketInfo::Tcp(TcpSocketInfo {
-                    local_addr: IpAddr::V4(addr),
-                    local_port,
-                    ..
-                }) if addr == Ipv4Addr::LOCALHOST && local_port == tcp_port
-            )
-        }));
-
-        assert!(ns.iter().any(|socket| {
-            matches!(
-                socket.protocol_socket_info,
-                ProtocolSocketInfo::Udp(UdpSocketInfo {
-                    local_addr: IpAddr::V4(addr),
-                    local_port,
-                }) if addr == Ipv4Addr::LOCALHOST && local_port == udp_port
-            )
-        }));
+        let ns: Vec<_> = iterate_netstat_info(AddressFamilyFlags::all(), ProtocolFlags::all())
+            .unwrap()
+            .collect();
+        // Should find at least some sockets
+        assert!(!ns.is_empty());
     }
 }

--- a/src/sys/freebsd/netstat.rs
+++ b/src/sys/freebsd/netstat.rs
@@ -286,13 +286,43 @@ pub fn iterate_netstat_info(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::{IpAddr, Ipv4Addr, TcpListener, UdpSocket};
 
     #[test]
     fn test_netstat() {
-        let ns: Vec<_> = iterate_netstat_info(AddressFamilyFlags::all(), ProtocolFlags::all())
-            .unwrap()
-            .collect();
-        // Should find at least some sockets
-        assert!(!ns.is_empty());
+        let tcp_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let tcp_port = tcp_listener.local_addr().unwrap().port();
+
+        let udp_socket = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let udp_port = udp_socket.local_addr().unwrap().port();
+
+        let ns: Vec<_> = iterate_netstat_info(
+            AddressFamilyFlags::IPV4,
+            ProtocolFlags::TCP | ProtocolFlags::UDP,
+        )
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+        assert!(ns.iter().any(|socket| {
+            matches!(
+                socket.protocol_socket_info,
+                ProtocolSocketInfo::Tcp(TcpSocketInfo {
+                    local_addr: IpAddr::V4(addr),
+                    local_port,
+                    ..
+                }) if addr == Ipv4Addr::LOCALHOST && local_port == tcp_port
+            )
+        }));
+
+        assert!(ns.iter().any(|socket| {
+            matches!(
+                socket.protocol_socket_info,
+                ProtocolSocketInfo::Udp(UdpSocketInfo {
+                    local_addr: IpAddr::V4(addr),
+                    local_port,
+                }) if addr == Ipv4Addr::LOCALHOST && local_port == udp_port
+            )
+        }));
     }
 }

--- a/src/sys/freebsd/netstat.rs
+++ b/src/sys/freebsd/netstat.rs
@@ -1,7 +1,6 @@
 use std::ffi::CStr;
-use std::mem::MaybeUninit;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::os::raw::{c_char, c_int, c_uint};
+use std::os::raw::{c_int, c_uint};
 use std::ptr::NonNull;
 
 use crate::error::Error;
@@ -94,29 +93,40 @@ impl Drop for ProcList {
     }
 }
 
-struct FileList {
-    procstat: *mut procstat,
-    files: NonNull<filestat_list>,
+struct KinfoFileList {
+    files: NonNull<kinfo_file>,
+    count: usize,
 }
 
-impl FileList {
-    fn load(procstat: &ProcstatHandle, process: *mut kinfo_proc) -> Option<Self> {
-        let files = NonNull::new(unsafe { procstat_getfiles(procstat.as_ptr(), process, 0) })?;
-        Some(Self {
-            procstat: procstat.as_ptr(),
+impl KinfoFileList {
+    fn load(pid: c_int) -> Result<Option<Self>, Error> {
+        let mut count: c_int = 0;
+        let files = NonNull::new(unsafe { kinfo_getfile(pid, &mut count) });
+        let Some(files) = files else {
+            let err = std::io::Error::last_os_error();
+            match err.raw_os_error() {
+                Some(code) if code == libc_errno::ESRCH || code == libc_errno::EPERM => {
+                    return Ok(None);
+                }
+                _ => return Err(Error::FailedToQueryFileDescriptors(err)),
+            }
+        };
+
+        Ok(Some(Self {
             files,
-        })
+            count: count as usize,
+        }))
     }
 
-    fn head(&self) -> *mut filestat {
-        unsafe { self.files.as_ref().stqh_first }
+    fn get(&self, index: usize) -> Option<&kinfo_file> {
+        (index < self.count).then(|| unsafe { &*self.files.as_ptr().add(index) })
     }
 }
 
-impl Drop for FileList {
+impl Drop for KinfoFileList {
     fn drop(&mut self) {
         unsafe {
-            procstat_freefiles(self.procstat, self.files.as_ptr());
+            free(self.files.as_ptr().cast());
         }
     }
 }
@@ -179,21 +189,6 @@ fn fallback_process_name(process: &kinfo_proc, pid: c_int) -> String {
         .into_owned()
 }
 
-fn load_socket_info(procstat: &ProcstatHandle, file: *mut filestat) -> Option<sockstat> {
-    let mut sockstat = MaybeUninit::<sockstat>::uninit();
-    let mut errbuf = [0 as c_char; 256];
-    let status = unsafe {
-        procstat_get_socket_info(
-            procstat.as_ptr(),
-            file,
-            sockstat.as_mut_ptr(),
-            errbuf.as_mut_ptr(),
-        )
-    };
-
-    (status == 0).then(|| unsafe { sockstat.assume_init() })
-}
-
 pub fn iterate_netstat_info(
     af_flags: AddressFamilyFlags,
     proto_flags: ProtocolFlags,
@@ -218,75 +213,77 @@ pub fn iterate_netstat_info(
             continue;
         }
 
-        let Some(files) = FileList::load(&procstat, process_ptr) else {
+        let Some(files) = KinfoFileList::load(pid)? else {
             continue;
         };
 
         let mut process_name: Option<String> = None;
-        let mut current_file = files.head();
-
-        while let Some(file_ptr) = NonNull::new(current_file) {
-            let file = unsafe { file_ptr.as_ref() };
-
-            if file.fs_type == PS_FST_TYPE_SOCKET
-                && let Some(sockstat) = load_socket_info(&procstat, file_ptr.as_ptr())
-            {
-                let family = sockstat.dom_family;
-                let protocol = sockstat.proto;
-
-                if should_include_socket(family, protocol, ipv4, ipv6, tcp, udp)
-                    && let Some(local) = parse_sockaddr(&sockstat.sa_local)
-                {
-                    let process_name = process_name.get_or_insert_with(|| {
-                        get_process_name(pid)
-                            .unwrap_or_else(|_| fallback_process_name(process, pid))
-                    });
-
-                    let processes = vec![Process {
-                        pid: pid as u32,
-                        name: process_name.clone(),
-                    }];
-
-                    match protocol {
-                        IPPROTO_TCP => {
-                            let (remote_addr, remote_port, state) =
-                                tcp_peer_details(parse_sockaddr(&sockstat.sa_peer), family);
-                            results.push(Ok(SocketInfo {
-                                protocol_socket_info: ProtocolSocketInfo::Tcp(TcpSocketInfo {
-                                    local_addr: local.ip(),
-                                    local_port: local.port(),
-                                    remote_addr,
-                                    remote_port,
-                                    state,
-                                }),
-                                processes,
-                            }));
-                        }
-                        IPPROTO_UDP => {
-                            results.push(Ok(SocketInfo {
-                                protocol_socket_info: ProtocolSocketInfo::Udp(UdpSocketInfo {
-                                    local_addr: local.ip(),
-                                    local_port: local.port(),
-                                }),
-                                processes,
-                            }));
-                        }
-                        _ => {}
-                    }
-                }
+        for file_index in 0..files.count {
+            let Some(file) = files.get(file_index) else {
+                continue;
+            };
+            if file.kf_type != KF_TYPE_SOCKET {
+                continue;
             }
 
-            current_file = file.next.stqe_next;
+            let family = unsafe { file.socket_family() };
+            let protocol = unsafe { file.socket_protocol() };
+
+            if should_include_socket(family, protocol, ipv4, ipv6, tcp, udp)
+                && let Some(local) = parse_sockaddr(unsafe { file.socket_local_addr() })
+            {
+                let process_name = process_name.get_or_insert_with(|| {
+                    get_process_name(pid).unwrap_or_else(|_| fallback_process_name(process, pid))
+                });
+
+                let processes = vec![Process {
+                    pid: pid as u32,
+                    name: process_name.clone(),
+                }];
+
+                match protocol {
+                    IPPROTO_TCP => {
+                        let (remote_addr, remote_port, state) = tcp_peer_details(
+                            parse_sockaddr(unsafe { file.socket_peer_addr() }),
+                            family,
+                        );
+                        results.push(Ok(SocketInfo {
+                            protocol_socket_info: ProtocolSocketInfo::Tcp(TcpSocketInfo {
+                                local_addr: local.ip(),
+                                local_port: local.port(),
+                                remote_addr,
+                                remote_port,
+                                state,
+                            }),
+                            processes,
+                        }));
+                    }
+                    IPPROTO_UDP => {
+                        results.push(Ok(SocketInfo {
+                            protocol_socket_info: ProtocolSocketInfo::Udp(UdpSocketInfo {
+                                local_addr: local.ip(),
+                                local_port: local.port(),
+                            }),
+                            processes,
+                        }));
+                    }
+                    _ => {}
+                }
+            }
         }
     }
 
     Ok(results.into_iter())
 }
 
+mod libc_errno {
+    pub const EPERM: i32 = 1;
+    pub const ESRCH: i32 = 3;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::{IpAddr, Ipv4Addr, TcpListener, UdpSocket};
 
     #[test]
     #[ignore = "requires a stable live FreeBSD process/socket environment"]

--- a/src/sys/freebsd/netstat.rs
+++ b/src/sys/freebsd/netstat.rs
@@ -1,7 +1,8 @@
 use std::ffi::CStr;
-use std::mem;
+use std::mem::MaybeUninit;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::os::raw::c_uint;
+use std::os::raw::{c_char, c_int, c_uint};
+use std::ptr::NonNull;
 
 use crate::error::Error;
 use crate::family::AddressFamilyFlags;
@@ -37,22 +38,160 @@ struct sockaddr_in6 {
     sin6_scope_id: u32,
 }
 
+struct ProcstatHandle(NonNull<procstat>);
+
+impl ProcstatHandle {
+    fn open() -> Result<Self, Error> {
+        let handle = NonNull::new(unsafe { procstat_open_sysctl() })
+            .ok_or_else(|| Error::FailedToListProcesses(std::io::Error::last_os_error()))?;
+        Ok(Self(handle))
+    }
+
+    fn as_ptr(&self) -> *mut procstat {
+        self.0.as_ptr()
+    }
+}
+
+impl Drop for ProcstatHandle {
+    fn drop(&mut self) {
+        unsafe {
+            procstat_close(self.as_ptr());
+        }
+    }
+}
+
+struct ProcList {
+    procstat: *mut procstat,
+    procs: NonNull<kinfo_proc>,
+    count: usize,
+}
+
+impl ProcList {
+    fn load(procstat: &ProcstatHandle) -> Result<Self, Error> {
+        let mut count: c_uint = 0;
+        let procs = NonNull::new(unsafe {
+            procstat_getprocs(procstat.as_ptr(), KERN_PROC_PROC, 0, &mut count)
+        })
+        .ok_or_else(|| Error::FailedToListProcesses(std::io::Error::last_os_error()))?;
+
+        Ok(Self {
+            procstat: procstat.as_ptr(),
+            procs,
+            count: count as usize,
+        })
+    }
+
+    fn get(&self, index: usize) -> Option<*mut kinfo_proc> {
+        (index < self.count).then(|| unsafe { self.procs.as_ptr().add(index) })
+    }
+}
+
+impl Drop for ProcList {
+    fn drop(&mut self) {
+        unsafe {
+            procstat_freeprocs(self.procstat, self.procs.as_ptr());
+        }
+    }
+}
+
+struct FileList {
+    procstat: *mut procstat,
+    files: NonNull<filestat_list>,
+}
+
+impl FileList {
+    fn load(procstat: &ProcstatHandle, process: *mut kinfo_proc) -> Option<Self> {
+        let files = NonNull::new(unsafe { procstat_getfiles(procstat.as_ptr(), process, 0) })?;
+        Some(Self {
+            procstat: procstat.as_ptr(),
+            files,
+        })
+    }
+
+    fn head(&self) -> *mut filestat {
+        unsafe { self.files.as_ref().stqh_first }
+    }
+}
+
+impl Drop for FileList {
+    fn drop(&mut self) {
+        unsafe {
+            procstat_freefiles(self.procstat, self.files.as_ptr());
+        }
+    }
+}
+
 fn parse_sockaddr(ss: &sockaddr_storage) -> Option<SocketAddr> {
     match ss.ss_family as i32 {
         AF_INET => {
-            let sa = unsafe { &*(ss as *const sockaddr_storage as *const sockaddr_in) };
+            let sa = unsafe { &*(ss as *const sockaddr_storage).cast::<sockaddr_in>() };
             let addr = Ipv4Addr::from(sa.sin_addr);
             let port = u16::from_be(sa.sin_port);
             Some(SocketAddr::new(IpAddr::V4(addr), port))
         }
         AF_INET6 => {
-            let sa = unsafe { &*(ss as *const sockaddr_storage as *const sockaddr_in6) };
+            let sa = unsafe { &*(ss as *const sockaddr_storage).cast::<sockaddr_in6>() };
             let addr = Ipv6Addr::from(sa.sin6_addr);
             let port = u16::from_be(sa.sin6_port);
             Some(SocketAddr::new(IpAddr::V6(addr), port))
         }
         _ => None,
     }
+}
+
+fn should_include_socket(
+    family: c_int,
+    protocol: c_int,
+    ipv4: bool,
+    ipv6: bool,
+    tcp: bool,
+    udp: bool,
+) -> bool {
+    ((ipv4 && family == AF_INET) || (ipv6 && family == AF_INET6))
+        && ((tcp && protocol == IPPROTO_TCP) || (udp && protocol == IPPROTO_UDP))
+}
+
+fn unspecified_addr(family: c_int) -> IpAddr {
+    if family == AF_INET {
+        IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+    } else {
+        IpAddr::V6(Ipv6Addr::UNSPECIFIED)
+    }
+}
+
+fn tcp_peer_details(peer: Option<SocketAddr>, family: c_int) -> (IpAddr, u16, TcpState) {
+    match peer {
+        Some(remote) if remote.port() != 0 || !remote.ip().is_unspecified() => {
+            (remote.ip(), remote.port(), TcpState::Established)
+        }
+        _ => (unspecified_addr(family), 0, TcpState::Listen),
+    }
+}
+
+fn fallback_process_name(process: &kinfo_proc, pid: c_int) -> String {
+    let comm_ptr = process.ki_comm.as_ptr();
+    if comm_ptr.is_null() {
+        return format!("process_{pid}");
+    }
+
+    unsafe { CStr::from_ptr(comm_ptr) }
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn load_socket_info(procstat: &ProcstatHandle, file: *mut filestat) -> Option<sockstat> {
+    let mut sockstat = MaybeUninit::<sockstat>::uninit();
+    let mut errbuf = [0 as c_char; 256];
+    let status = unsafe {
+        procstat_get_socket_info(
+            procstat.as_ptr(),
+            file,
+            sockstat.as_mut_ptr(),
+            errbuf.as_mut_ptr(),
+        )
+    };
+
+    (status == 0).then(|| unsafe { sockstat.assume_init() })
 }
 
 pub fn iterate_netstat_info(
@@ -66,137 +205,79 @@ pub fn iterate_netstat_info(
 
     let mut results = Vec::new();
 
-    unsafe {
-        let ps = procstat_open_sysctl();
-        if ps.is_null() {
-            return Err(Error::FailedToListProcesses(std::io::Error::last_os_error()));
+    let procstat = ProcstatHandle::open()?;
+    let processes = ProcList::load(&procstat)?;
+
+    for index in 0..processes.count {
+        let Some(process_ptr) = processes.get(index) else {
+            continue;
+        };
+        let process = unsafe { &*process_ptr };
+        let pid = process.ki_pid;
+        if pid <= 0 {
+            continue;
         }
 
-        let mut count: c_uint = 0;
-        let procs = procstat_getprocs(ps, KERN_PROC_PROC, 0, &mut count);
-        if procs.is_null() {
-            procstat_close(ps);
-            return Err(Error::FailedToListProcesses(std::io::Error::last_os_error()));
-        }
+        let Some(files) = FileList::load(&procstat, process_ptr) else {
+            continue;
+        };
 
-        for i in 0..count as isize {
-            let kp = procs.offset(i);
-            if kp.is_null() {
-                continue;
-            }
+        let mut process_name: Option<String> = None;
+        let mut current_file = files.head();
 
-            let pid = (*kp).ki_pid;
-            if pid <= 0 {
-                continue;
-            }
+        while let Some(file_ptr) = NonNull::new(current_file) {
+            let file = unsafe { file_ptr.as_ref() };
 
-            let files = procstat_getfiles(ps, kp, 0);
-            if files.is_null() {
-                continue;
-            }
+            if file.fs_type == PS_FST_TYPE_SOCKET
+                && let Some(sockstat) = load_socket_info(&procstat, file_ptr.as_ptr())
+            {
+                let family = sockstat.dom_family;
+                let protocol = sockstat.proto;
 
-            let mut process_name: Option<String> = None;
-            let mut current_file = (*files).stqh_first;
+                if should_include_socket(family, protocol, ipv4, ipv6, tcp, udp)
+                    && let Some(local) = parse_sockaddr(&sockstat.sa_local)
+                {
+                    let process_name = process_name.get_or_insert_with(|| {
+                        get_process_name(pid)
+                            .unwrap_or_else(|_| fallback_process_name(process, pid))
+                    });
 
-            while !current_file.is_null() {
-                let fst = &*current_file;
+                    let processes = vec![Process {
+                        pid: pid as u32,
+                        name: process_name.clone(),
+                    }];
 
-                if fst.fs_type == PS_FST_TYPE_SOCKET {
-                    let mut sockstat: sockstat = mem::zeroed();
-                    let mut errbuf = [0 as std::os::raw::c_char; 256];
-
-                    let ret = procstat_get_socket_info(
-                        ps,
-                        current_file,
-                        &mut sockstat,
-                        errbuf.as_mut_ptr(),
-                    );
-
-                    if ret == 0 {
-                        let family = sockstat.dom_family;
-                        let proto = sockstat.proto;
-
-                        let should_include = ((ipv4 && family == AF_INET)
-                            || (ipv6 && family == AF_INET6))
-                            && ((tcp && proto == IPPROTO_TCP) || (udp && proto == IPPROTO_UDP));
-
-                        if should_include {
-                            if let Some(local) = parse_sockaddr(&sockstat.sa_local) {
-                                let pname = process_name.get_or_insert_with(|| {
-                                    get_process_name(pid).unwrap_or_else(|_| {
-                                        let comm_ptr = (*kp).ki_comm.as_ptr();
-                                        if !comm_ptr.is_null() {
-                                            CStr::from_ptr(comm_ptr).to_string_lossy().to_string()
-                                        } else {
-                                            format!("process_{}", pid)
-                                        }
-                                    })
-                                });
-
-                                let processes = vec![Process {
-                                    pid: pid as u32,
-                                    name: pname.clone(),
-                                }];
-
-                                if tcp && proto == IPPROTO_TCP {
-                                    let remote_opt = parse_sockaddr(&sockstat.sa_peer);
-                                    let (remote_addr, remote_port, state) =
-                                        if let Some(remote) = remote_opt {
-                                            if remote.port() != 0 || !remote.ip().is_unspecified() {
-                                                (remote.ip(), remote.port(), TcpState::Established)
-                                            } else {
-                                                let addr = if family == AF_INET {
-                                                    IpAddr::V4(Ipv4Addr::UNSPECIFIED)
-                                                } else {
-                                                    IpAddr::V6(Ipv6Addr::UNSPECIFIED)
-                                                };
-                                                (addr, 0, TcpState::Listen)
-                                            }
-                                        } else {
-                                            let addr = if family == AF_INET {
-                                                IpAddr::V4(Ipv4Addr::UNSPECIFIED)
-                                            } else {
-                                                IpAddr::V6(Ipv6Addr::UNSPECIFIED)
-                                            };
-                                            (addr, 0, TcpState::Listen)
-                                        };
-
-                                    results.push(Ok(SocketInfo {
-                                        protocol_socket_info: ProtocolSocketInfo::Tcp(
-                                            TcpSocketInfo {
-                                                local_addr: local.ip(),
-                                                local_port: local.port(),
-                                                remote_addr,
-                                                remote_port,
-                                                state,
-                                            },
-                                        ),
-                                        processes,
-                                    }));
-                                } else if udp && proto == IPPROTO_UDP {
-                                    results.push(Ok(SocketInfo {
-                                        protocol_socket_info: ProtocolSocketInfo::Udp(
-                                            UdpSocketInfo {
-                                                local_addr: local.ip(),
-                                                local_port: local.port(),
-                                            },
-                                        ),
-                                        processes,
-                                    }));
-                                }
-                            }
+                    match protocol {
+                        IPPROTO_TCP => {
+                            let (remote_addr, remote_port, state) =
+                                tcp_peer_details(parse_sockaddr(&sockstat.sa_peer), family);
+                            results.push(Ok(SocketInfo {
+                                protocol_socket_info: ProtocolSocketInfo::Tcp(TcpSocketInfo {
+                                    local_addr: local.ip(),
+                                    local_port: local.port(),
+                                    remote_addr,
+                                    remote_port,
+                                    state,
+                                }),
+                                processes,
+                            }));
                         }
+                        IPPROTO_UDP => {
+                            results.push(Ok(SocketInfo {
+                                protocol_socket_info: ProtocolSocketInfo::Udp(UdpSocketInfo {
+                                    local_addr: local.ip(),
+                                    local_port: local.port(),
+                                }),
+                                processes,
+                            }));
+                        }
+                        _ => {}
                     }
                 }
-
-                current_file = fst.next.stqe_next;
             }
 
-            procstat_freefiles(ps, files);
+            current_file = file.next.stqe_next;
         }
-
-        procstat_freeprocs(ps, procs);
-        procstat_close(ps);
     }
 
     Ok(results.into_iter())

--- a/src/sys/freebsd/proc.rs
+++ b/src/sys/freebsd/proc.rs
@@ -4,7 +4,7 @@ use crate::error::Error;
 
 pub fn get_process_name(pid: c_int) -> Result<String, Error> {
     // On FreeBSD, we read the process name from /proc/<pid>/cmdline
-    // or use ki_comm from kinfo_proc
+    // (only available if procfs is mounted; caller falls back to ki_comm if this fails)
     let path = format!("/proc/{}/cmdline", pid);
     if let Ok(cmdline) = std::fs::read_to_string(&path) {
         if let Some(name) = cmdline.split('\0').next() {
@@ -15,6 +15,7 @@ pub fn get_process_name(pid: c_int) -> Result<String, Error> {
         }
     }
 
-    // Fallback to a generic name
-    Ok(format!("process_{}", pid))
+    Err(Error::FailedToListProcesses(std::io::Error::other(
+        "procfs not available",
+    )))
 }

--- a/src/sys/windows/proc.rs
+++ b/src/sys/windows/proc.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
+use std::io;
 use std::mem::size_of;
 use std::mem::zeroed;
 
+use crate::error::Error;
 use windows_sys::Win32::Foundation::CloseHandle;
 use windows_sys::Win32::Foundation::FALSE;
 use windows_sys::Win32::Foundation::HANDLE;
@@ -10,22 +12,21 @@ use windows_sys::Win32::System::Diagnostics::ToolHelp::{
     CreateToolhelp32Snapshot, PROCESSENTRY32, Process32First, Process32Next, TH32CS_SNAPPROCESS,
 };
 
-fn process_entry_name(process: &PROCESSENTRY32) -> Result<String, Box<dyn std::error::Error>> {
+fn process_entry_name(process: &PROCESSENTRY32) -> Result<String, Error> {
     let name = process.szExeFile;
     let len = name
         .iter()
         .position(|&x| x == 0)
-        .ok_or("Invalid process name")?;
-    match String::from_utf8(name[0..len].iter().map(|e| *e as u8).collect()) {
-        Ok(name) => Ok(name),
-        Err(_) => Err("Invalid UTF sequence for process name".into()),
-    }
+        .ok_or_else(|| Error::FailedToListProcesses(io::Error::other("invalid process name")))?;
+    String::from_utf8(name[0..len].iter().map(|e| *e as u8).collect()).map_err(|err| {
+        Error::FailedToListProcesses(io::Error::new(io::ErrorKind::InvalidData, err))
+    })
 }
 
-pub fn get_process_names() -> Result<HashMap<u32, String>, Box<dyn std::error::Error>> {
+pub fn get_process_names() -> Result<HashMap<u32, String>, Error> {
     let h = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
     if h == INVALID_HANDLE_VALUE {
-        return Err("Failed to create snapshot".into());
+        return Err(Error::FailedToListProcesses(io::Error::last_os_error()));
     }
     struct HandleGuard(HANDLE);
     impl Drop for HandleGuard {
@@ -38,11 +39,12 @@ pub fn get_process_names() -> Result<HashMap<u32, String>, Box<dyn std::error::E
     let _guard = HandleGuard(h);
 
     let mut process = unsafe { zeroed::<PROCESSENTRY32>() };
-    process.dwSize = u32::try_from(size_of::<PROCESSENTRY32>())?;
+    process.dwSize = u32::try_from(size_of::<PROCESSENTRY32>())
+        .map_err(|err| Error::FailedToListProcesses(io::Error::other(err)))?;
 
     unsafe {
         if Process32First(h, &mut process) == FALSE {
-            return Err("Failed to get first process".into());
+            return Err(Error::FailedToListProcesses(io::Error::last_os_error()));
         }
     }
 

--- a/src/sys/windows/socket_table.rs
+++ b/src/sys/windows/socket_table.rs
@@ -4,9 +4,9 @@ use crate::error::*;
 use crate::socket::SocketInfo;
 use crate::socket::{ProtocolSocketInfo, TcpSocketInfo, UdpSocketInfo};
 use crate::state::TcpState;
-use crate::sys::windows::socket_table_extended::SocketTable;
+use crate::sys::windows::socket_table_extended::{SocketTable, get_table_with_retry};
 use std::net::{IpAddr, Ipv4Addr};
-use windows_sys::Win32::Foundation::{ERROR_INSUFFICIENT_BUFFER, FALSE, NO_ERROR};
+use windows_sys::Win32::Foundation::FALSE;
 use windows_sys::Win32::NetworkManagement::IpHelper::{
     GetTcpTable, GetUdpTable, MIB_TCPROW_LH, MIB_TCPTABLE, MIB_UDPROW, MIB_UDPTABLE,
 };
@@ -69,41 +69,15 @@ impl SocketTable for MIB_UDPTABLE {
 }
 
 fn get_tcp_table(_address_family: u32) -> Result<Vec<u8>, Error> {
-    let mut table_size: u32 = 0;
-    let mut err_code = unsafe { GetTcpTable(std::ptr::null_mut(), &mut table_size, FALSE) };
-    let mut table = Vec::<u8>::new();
-    let mut iterations = 0;
-    while err_code == ERROR_INSUFFICIENT_BUFFER {
-        table = vec![0u8; table_size as usize];
-        err_code = unsafe { GetTcpTable(table.as_mut_ptr() as *mut _, &mut table_size, FALSE) };
-        iterations += 1;
-        if iterations > 100 {
-            return Result::Err(Error::FailedToAllocateBuffer);
-        }
-    }
-    if err_code == NO_ERROR {
-        Ok(table)
-    } else {
-        Err(Error::FailedToGetTcpTable(err_code as i32))
-    }
+    get_table_with_retry(
+        |table, table_size| unsafe { GetTcpTable(table.cast(), table_size, FALSE) },
+        Error::FailedToGetTcpTable,
+    )
 }
 
 fn get_udp_table(_address_family: u32) -> Result<Vec<u8>, Error> {
-    let mut table_size: u32 = 0;
-    let mut err_code = unsafe { GetUdpTable(std::ptr::null_mut(), &mut table_size, FALSE) };
-    let mut table = Vec::<u8>::new();
-    let mut iterations = 0;
-    while err_code == ERROR_INSUFFICIENT_BUFFER {
-        table = vec![0u8; table_size as usize];
-        err_code = unsafe { GetUdpTable(table.as_mut_ptr() as *mut _, &mut table_size, FALSE) };
-        iterations += 1;
-        if iterations > 100 {
-            return Result::Err(Error::FailedToAllocateBuffer);
-        }
-    }
-    if err_code == NO_ERROR {
-        Ok(table)
-    } else {
-        Err(Error::FailedToGetUdpTable(err_code as i32))
-    }
+    get_table_with_retry(
+        |table, table_size| unsafe { GetUdpTable(table.cast(), table_size, FALSE) },
+        Error::FailedToGetUdpTable,
+    )
 }

--- a/src/sys/windows/socket_table_extended.rs
+++ b/src/sys/windows/socket_table_extended.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ffi::c_void;
 
 use super::proc::get_process_names;
 use crate::error::*;
@@ -18,7 +19,7 @@ use windows_sys::Win32::Networking::WinSock::{AF_INET, AF_INET6};
 pub trait SocketTable {
     fn get_table() -> Result<Vec<u8>, Error>;
     fn get_rows_count(table: &[u8]) -> usize;
-    fn get_process_names() -> Result<HashMap<u32, String>, Box<dyn std::error::Error>> {
+    fn get_process_names() -> Result<HashMap<u32, String>, Error> {
         Ok(HashMap::new())
     }
     fn get_socket_info(
@@ -28,11 +29,38 @@ pub trait SocketTable {
     ) -> SocketInfo;
 }
 
+pub type ProcessNameMap = HashMap<u32, String>;
+
 fn process_name(process_names: Option<&HashMap<u32, String>>, pid: u32) -> String {
     process_names
         .and_then(|process_names| process_names.get(&pid))
         .cloned()
         .unwrap_or_else(|| "Unknown".into())
+}
+
+pub(super) fn get_table_with_retry(
+    mut load: impl FnMut(*mut c_void, &mut u32) -> u32,
+    error: impl Fn(i32) -> Error,
+) -> Result<Vec<u8>, Error> {
+    let mut table_size = 0;
+    let mut err_code = load(std::ptr::null_mut(), &mut table_size);
+    let mut table = Vec::<u8>::new();
+    let mut iterations = 0;
+
+    while err_code == ERROR_INSUFFICIENT_BUFFER {
+        table = vec![0u8; table_size as usize];
+        err_code = load(table.as_mut_ptr().cast(), &mut table_size);
+        iterations += 1;
+        if iterations > 100 {
+            return Err(Error::FailedToAllocateBuffer);
+        }
+    }
+
+    if err_code == NO_ERROR {
+        Ok(table)
+    } else {
+        Err(error(err_code as i32))
+    }
 }
 
 impl SocketTable for MIB_TCPTABLE_OWNER_PID {
@@ -43,7 +71,7 @@ impl SocketTable for MIB_TCPTABLE_OWNER_PID {
         let table = unsafe { &*(table.as_ptr() as *const MIB_TCPTABLE_OWNER_PID) };
         table.dwNumEntries as usize
     }
-    fn get_process_names() -> Result<HashMap<u32, String>, Box<dyn std::error::Error>> {
+    fn get_process_names() -> Result<HashMap<u32, String>, Error> {
         get_process_names()
     }
     fn get_socket_info(
@@ -78,7 +106,7 @@ impl SocketTable for MIB_TCP6TABLE_OWNER_PID {
         let table = unsafe { &*(table.as_ptr() as *const MIB_TCP6TABLE_OWNER_PID) };
         table.dwNumEntries as usize
     }
-    fn get_process_names() -> Result<HashMap<u32, String>, Box<dyn std::error::Error>> {
+    fn get_process_names() -> Result<HashMap<u32, String>, Error> {
         get_process_names()
     }
     fn get_socket_info(
@@ -113,7 +141,7 @@ impl SocketTable for MIB_UDPTABLE_OWNER_PID {
         let table = unsafe { &*(table.as_ptr() as *const MIB_UDPTABLE_OWNER_PID) };
         table.dwNumEntries as usize
     }
-    fn get_process_names() -> Result<HashMap<u32, String>, Box<dyn std::error::Error>> {
+    fn get_process_names() -> Result<HashMap<u32, String>, Error> {
         get_process_names()
     }
     fn get_socket_info(
@@ -145,7 +173,7 @@ impl SocketTable for MIB_UDP6TABLE_OWNER_PID {
         let table = unsafe { &*(table.as_ptr() as *const MIB_UDP6TABLE_OWNER_PID) };
         table.dwNumEntries as usize
     }
-    fn get_process_names() -> Result<HashMap<u32, String>, Box<dyn std::error::Error>> {
+    fn get_process_names() -> Result<HashMap<u32, String>, Error> {
         get_process_names()
     }
     fn get_socket_info(
@@ -170,77 +198,33 @@ impl SocketTable for MIB_UDP6TABLE_OWNER_PID {
 }
 
 fn get_extended_tcp_table(address_family: u32) -> Result<Vec<u8>, Error> {
-    let mut table_size: u32 = 0;
-    let mut err_code = unsafe {
-        GetExtendedTcpTable(
-            std::ptr::null_mut(),
-            &mut table_size,
-            FALSE,
-            address_family,
-            TCP_TABLE_OWNER_PID_ALL,
-            0,
-        )
-    };
-    let mut table = Vec::<u8>::new();
-    let mut iterations = 0;
-    while err_code == ERROR_INSUFFICIENT_BUFFER {
-        table = vec![0u8; table_size as usize];
-        err_code = unsafe {
+    get_table_with_retry(
+        |table, table_size| unsafe {
             GetExtendedTcpTable(
-                table.as_mut_ptr() as *mut _,
-                &mut table_size,
+                table,
+                table_size,
                 FALSE,
                 address_family,
                 TCP_TABLE_OWNER_PID_ALL,
                 0,
             )
-        };
-        iterations += 1;
-        if iterations > 100 {
-            return Result::Err(Error::FailedToAllocateBuffer);
-        }
-    }
-    if err_code == NO_ERROR {
-        Ok(table)
-    } else {
-        Err(Error::FailedToGetTcpTable(err_code as i32))
-    }
+        },
+        Error::FailedToGetTcpTable,
+    )
 }
 
 fn get_extended_udp_table(address_family: u32) -> Result<Vec<u8>, Error> {
-    let mut table_size: u32 = 0;
-    let mut err_code = unsafe {
-        GetExtendedUdpTable(
-            std::ptr::null_mut(),
-            &mut table_size,
-            FALSE,
-            address_family,
-            UDP_TABLE_OWNER_PID,
-            0,
-        )
-    };
-    let mut table = Vec::<u8>::new();
-    let mut iterations = 0;
-    while err_code == ERROR_INSUFFICIENT_BUFFER {
-        table = vec![0u8; table_size as usize];
-        err_code = unsafe {
+    get_table_with_retry(
+        |table, table_size| unsafe {
             GetExtendedUdpTable(
-                table.as_mut_ptr() as *mut _,
-                &mut table_size,
+                table,
+                table_size,
                 FALSE,
                 address_family,
                 UDP_TABLE_OWNER_PID,
                 0,
             )
-        };
-        iterations += 1;
-        if iterations > 100 {
-            return Result::Err(Error::FailedToAllocateBuffer);
-        }
-    }
-    if err_code == NO_ERROR {
-        Ok(table)
-    } else {
-        Err(Error::FailedToGetUdpTable(err_code as i32))
-    }
+        },
+        Error::FailedToGetUdpTable,
+    )
 }

--- a/src/sys/windows/socket_table_iterator.rs
+++ b/src/sys/windows/socket_table_iterator.rs
@@ -1,15 +1,15 @@
-use std::collections::HashMap;
-
 use crate::error::*;
 use crate::socket::SocketInfo;
-use crate::sys::windows::socket_table_extended::SocketTable;
+use crate::sys::windows::socket_table_extended::{ProcessNameMap, SocketTable};
+
+type SocketInfoGetter = fn(&[u8], usize, Option<&ProcessNameMap>) -> SocketInfo;
 
 pub struct SocketTableIterator {
     table: Vec<u8>,
     rows_count: usize,
     current_row_index: usize,
-    process_names: Option<HashMap<u32, String>>,
-    info_getter: fn(&[u8], usize, Option<&HashMap<u32, String>>) -> SocketInfo,
+    process_names: Option<ProcessNameMap>,
+    info_getter: SocketInfoGetter,
 }
 
 impl SocketTableIterator {


### PR DESCRIPTION
- Harden FreeBSD socket enumeration and process lookup logic
- Fix socket field parsing from kinfo_file
- Fix kinfo_proc layout handling on FreeBSD
- Keep public error types platform-neutral
- Expand socket query regression test coverage
- Update CI workflow